### PR TITLE
Fix undersired selection of Arm64 AMI for Linux DCV hosts

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,8 +23,8 @@ CONFIG = {
    "region": "<region>", #AWS Region
    "account": "<account>", #AWS account number
    "ec2_type_enginframe": "t2.2xlarge", #EnginFrame instance type  
-   "ec2_type_dcv_linux": "g4dn.xlarge", #DCV Linux instance type  
-   "ec2_type_dcv_windows": "g4dn.xlarge", #DCV Windows instance type
+   "ec2_type_dcv_linux": "g4dn.xlarge", #DCV Linux instance type (x86 instances only) 
+   "ec2_type_dcv_windows": "g4dn.xlarge", #DCV Windows instance type (x86 instances only)
    "linux_dcv_number": 1, #Number of DCV Linux nodes
    "windows_dcv_number": 1, #Number of DCV Windows nodes
    "arn_efadmin_password": "<arn_secret>", # ARN of the secret that contains the efadmin password

--- a/dcv_session_manager_infrastructure/dcv_session_manager_infrastructure_stack.py
+++ b/dcv_session_manager_infrastructure/dcv_session_manager_infrastructure_stack.py
@@ -197,7 +197,8 @@ class DcvSessionManagerInfrastructureStack(core.Stack):
         linux_ami_enginframe = ec2.AmazonLinuxImage(generation=ec2.AmazonLinuxGeneration.AMAZON_LINUX_2,
                                                     edition=ec2.AmazonLinuxEdition.STANDARD,
                                                     virtualization=ec2.AmazonLinuxVirt.HVM,
-                                                    storage=ec2.AmazonLinuxStorage.GENERAL_PURPOSE
+                                                    storage=ec2.AmazonLinuxStorage.GENERAL_PURPOSE,
+                                                    cpu_type=ec2.AmazonLinuxCpuType.X86_64
                                                     )
         # EnginFrame instance ASG
         asg_enginframe = self.create_asg("Enginframe", vpc, config['ec2_type_enginframe'], linux_ami_enginframe, enginframe_userdata,
@@ -219,7 +220,7 @@ class DcvSessionManagerInfrastructureStack(core.Stack):
         dcv_linux_userdata.add_commands(data_dcv_linux_format)
         # Search for the latest AMIs for the instances
         linux_ami_dcv_linux = ec2.MachineImage.lookup(
-            name="DCV-AmazonLinux2*NVIDIA*",
+            name="DCV-AmazonLinux2-x86_64-*-NVIDIA-*",
             owners=["amazon"]
         )
         # Linux DCV instances ASG


### PR DESCRIPTION
Fix issue with Arm AMI being found and used for Linux DCV host regardless of instance type selected - enforce x86 AMI usage for now; can be generalized if desired.

*Issue #, if available:*
- n/a

*Description of changes:*
- Update comment in `app.py` to alert users to the requirement
- Use `AmazonLinuxImage` parameter to filter for x86_64 versions of AL2 for the EF host
- Update the AMI name search string to match the 2022 naming convention for the Linux DCV hosts, and add x86 as a requirement

*To do*:
- Enable the selection of x86 or Arm instance types, with the correct DCV AMI selected transparently.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
